### PR TITLE
Update defaults for hostnames and email addresses

### DIFF
--- a/compose/production/traefik/traefik.yml
+++ b/compose/production/traefik/traefik.yml
@@ -17,7 +17,7 @@ certificatesResolvers:
   letsencrypt:
     # https://docs.traefik.io/master/https/acme/#lets-encrypt
     acme:
-      email: "reprohack.team@gmail.com"
+      email: "reprohack-hub@sheffield.ac.uk"
       storage: /etc/traefik/acme/acme.json
       # https://docs.traefik.io/master/https/acme/#httpchallenge
       httpChallenge:
@@ -26,7 +26,7 @@ certificatesResolvers:
 http:
   routers:
     web-router:
-      rule: "Host(`reprohack.sheffield.ac.uk`)"
+      rule: "Host(`reprohack.org`)"
       entryPoints:
         - web
       middlewares:
@@ -35,7 +35,7 @@ http:
       service: django
 
     web-secure-router:
-      rule: "Host(`reprohack.sheffield.ac.uk`)"
+      rule: "Host(`reprohack.org`)"
       entryPoints:
         - web-secure
       middlewares:
@@ -46,7 +46,7 @@ http:
         certResolver: letsencrypt
 
     flower-secure-router:
-      rule: "Host(`reprohack.sheffield.ac.uk`)"
+      rule: "Host(`reprohack.org`)"
       entryPoints:
         - flower
       service: flower

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -6,7 +6,7 @@ from .base import env
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["reprohack.sheffield.ac.uk"])
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["reprohack.org"])
 
 # DATABASES
 # ------------------------------------------------------------------------------
@@ -77,7 +77,7 @@ TEMPLATES[-1]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
 DEFAULT_FROM_EMAIL = env(
-    "DJANGO_DEFAULT_FROM_EMAIL", default="ReproHack Hub <noreply@reprohack.sheffield.ac.uk>"
+    "DJANGO_DEFAULT_FROM_EMAIL", default="ReproHack Hub <reprohack-hub@sheffield.ac.uk>"
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)

--- a/reprohack_hub/contrib/sites/migrations/0003_set_site_domain_and_name.py
+++ b/reprohack_hub/contrib/sites/migrations/0003_set_site_domain_and_name.py
@@ -13,7 +13,7 @@ def update_site_forward(apps, schema_editor):
     Site.objects.update_or_create(
         id=settings.SITE_ID,
         defaults={
-            "domain": "reprohack.sheffield.ac.uk",
+            "domain": "reprohack.org",
             "name": "ReproHack Hub",
         },
     )


### PR DESCRIPTION
- Use a more generic hostname in the traefik/django configs
- Use a valid email in the traefik/django configs

NB these changes are housekeeping rather than vital as they should be overridable in production using environment vars. 