### PR TITLE
Add GDAL library (as is a run-time dependency)

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update \
   && apt-get install -y build-essential \
   # psycopg2 dependencies
   && apt-get install -y libpq-dev \
+  # GDAL lib
+  && apt-get install -y libgdal20 libgdal-dev \
   # Translations dependencies
   && apt-get install -y gettext \
   # Postgis for geospatial queries

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update \
   && apt-get install -y build-essential \
   # psycopg2 dependencies
   && apt-get install -y libpq-dev \
+  # GDAL lib
+  && apt-get install -y libgdal20 libgdal-dev \
   # Translations dependencies
   && apt-get install -y gettext \
   # cleaning up unused files


### PR DESCRIPTION
Discovered that GDAL is needed in the Django container after I did a `docker-compose -f production.yml up` on the dev branch.   

Addresses #40