### PR TITLE
Ensure Linter Travis CI job never fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ jobs:
       before_script:
         - pip install -q flake8
       script:
-        - "flake8"
+        # Force Flake8 to use the exit status code 0 even if there are errors.
+        # @TODO: remove '--exit-zero' once Python code has been cleaned up.
+        - "flake8 --exit-zero"
 
     - name: "Django Test"
       before_script:


### PR DESCRIPTION
Can re-enable once Python code has been cleaned up and flake8 is happy.

Addresses #50.