### PR TITLE
Looser pining of traefik base img

### DIFF
--- a/compose/production/traefik/Dockerfile
+++ b/compose/production/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:v2.3.1
+FROM traefik:v2.3
 RUN mkdir -p /etc/traefik/acme
 RUN touch /etc/traefik/acme/acme.json
 RUN chmod 600 /etc/traefik/acme/acme.json


### PR DESCRIPTION
There's no need to pin the patch version; pinning the minor version should be sufficient and will allow us to benefit from bug fixes when we rebuild/redeploy.